### PR TITLE
Set default environment to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
+# For Sinatra configuration, defaults to production. 
+# For local development, set this value to development
+APP_ENV=production
+
 # Find your Account SID and Auth Token at:
 # twilio.com/console
-export TWILIO_ACCOUNT_SID=AC2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-export TWILIO_AUTH_TOKEN=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_ACCOUNT_SID=AC2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_AUTH_TOKEN=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 # Find you Twilio number at:
 # https://www.twilio.com/console/phone-numbers/incoming
-export TWILIO_NUMBER=+15551230987
+TWILIO_NUMBER=+15551230987

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -49,5 +49,4 @@ jobs:
       - name: Run tests
         run: |
           cp .env.example .env
-          source .env
           bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'dotenv'
 gem 'sinatra'
 gem 'sinatra-contrib'
 gem 'haml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       dm-core (~> 1.2.0)
     do_postgres (0.10.17)
       data_objects (= 0.10.17)
+    dotenv (2.7.6)
     fakeweb (1.3.0)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
@@ -119,6 +120,7 @@ DEPENDENCIES
   database_cleaner
   dm-postgres-adapter
   dm-transactions
+  dotenv
   fakeweb
   haml
   pg
@@ -133,4 +135,4 @@ DEPENDENCIES
   vcr
 
 BUNDLED WITH
-  1.17.3
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ authentication yourself using SMS messages.
 
 [Read the full tutorial here!](https://www.twilio.com/docs/tutorials/walkthrough/sms-two-factor-authentication/ruby/sinatra)
 
-## Local development
+## Get started
 
 This project is built using the [Sinatra](http://www.sinatrarb.com/) web framework.
 
@@ -38,8 +38,6 @@ This project is built using the [Sinatra](http://www.sinatrarb.com/) web framewo
    [Twilio Account Settings](https://www.twilio.com/user/account/settings).
    You will also need a `TWILIO_NUMBER`, you may find [here](https://www.twilio.com/user/account/phone-numbers/incoming).
 
-   Run `source .env` to export the environment variables.
-
 1. Create development and test databases.
 
    Make sure you have installed [PostgreSQL](http://www.postgresql.org/). If on
@@ -63,6 +61,14 @@ This project is built using the [Sinatra](http://www.sinatrarb.com/) web framewo
    ```
 
 1. Check it out at [http://localhost:9292](http://localhost:9292).
+
+### Configure Development vs Production Settings
+
+By default, this application will run in production mode - stack traces will not be visible in the web browser. If you would like to run this application in development locally, change the `APP_ENV` variable in your `.env` file.
+
+`APP_ENV=development`
+
+For more about development vs production, visit [Sinatra's configuration page](http://sinatrarb.com/configuration.html).
 
 ## Meta
 

--- a/app.rb
+++ b/app.rb
@@ -1,4 +1,5 @@
-require 'sinatra/base'
+require 'dotenv'
+require 'sinatra'
 require 'sinatra/config_file'
 require 'rack-flash'
 require 'tilt/haml'
@@ -13,10 +14,16 @@ require_relative 'lib/code_generator'
 require_relative 'lib/message_sender'
 require_relative 'lib/verification_sender'
 
-ENV['RACK_ENV'] ||= 'development'
+# Load environment configuration
+Dotenv.load
+
+# Set the environment after dotenv loads
+# Default to production
+enviroment = (ENV['APP_ENV'] || ENV['RACK_ENV'] || :production).to_sym
+set :environment, enviroment
 
 require 'bundler'
-Bundler.require :default, ENV['RACK_ENV'].to_sym
+Bundler.require :default, enviroment
 
 module TwoFactorAuth
   class App < Sinatra::Base

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 ENV['RACK_ENV'] = 'test'
+ENV['APP_ENV'] = 'test'
 
 require_relative File.join('..', 'app')
 


### PR DESCRIPTION
Set default environment to production
Changes in the PR:

- Set `APP_ENV` to `production`
- Install dotenv
- Update README.